### PR TITLE
Update regional-planning version

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -19,12 +19,12 @@
 	{
 		"repo": "regional-planning",
 		"name": "regional-planning",
-		"ver": "d43f1512"
+		"ver": "a26cf79"
 	},
 	{
 		"repo": "regional-planning",
 		"name": "community_planning",
-		"ver": "d43f1512"
+		"ver": "a26cf79"
     }
   ]
 }


### PR DESCRIPTION
This PR updates the version of the regional-planning plugin to the latest commit.

#### Testing
* I changed the Jenkins config for this project so it would use the code on this branch, and then triggered a build, which can be seen at http://jenkins01.internal.azavea.com/view/TNC/job/TNC%20NY%20(prototype)/221/ I've since changed the configuration back to pointing to the `development` branch so I don't forget.
* Check that the info box appears to the right of the side bar in the regional planning plugin, since that was the last commit on regional planning.
